### PR TITLE
Add special case for Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const defaultNpmPrefix = (() => {
 		return path.dirname(process.execPath);
 	}
 
-	// Homebrew special case; always assume /usr/local
+	// Homebrew special case; always assume `/usr/local`
 	if (process.execPath.startsWith('/usr/local/Cellar/node')) {
 		return '/usr/local';
 	}

--- a/index.js
+++ b/index.js
@@ -20,6 +20,11 @@ const defaultNpmPrefix = (() => {
 		return path.dirname(process.execPath);
 	}
 
+	// Homebrew special case; always assume /usr/local
+	if (process.execPath.startsWith('/usr/local/Cellar/node')) {
+		return '/usr/local';
+	}
+
 	// `/usr/local/bin/node` → `prefix=/usr/local`
 	return path.dirname(path.dirname(process.execPath));
 })();


### PR DESCRIPTION
After poking at this a bit further, I found we'd need extra I/O to make this work in every case.

If, for example, your executable is `ava`, we can't use `process.env._` because it points to `/path/to/ava`.  If we instead ran `node node_modules/.bin/ava`, then `process.env._` would point to `node` in your `PATH`.

I've updated the code to check if `node` is indeed what the user executed; if that's the case, we can use `process.env._` to get at its path.  Otherwise, we just use `process.execPath`.  On my system, this is still incorrect when running `ava`.

If we wanted this to *always* work, we'd need to use `which` or something to that effect, and I assume you don't want to be invoking `child_process.anything()` here.