### PR TITLE
Refactor internals

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,6 @@ const readRc = filePath => {
 };
 
 const getEnvNpmPrefix = () => {
-	if (process.env.PREFIX) {
-		return process.env.PREFIX;
-	}
-
 	return Object.keys(process.env).reduce((prefix, name) => {
 		return (/^npm_config_prefix$/i).test(name) ? process.env[name] : prefix;
 	}, undefined);
@@ -25,16 +21,18 @@ const getEnvNpmPrefix = () => {
 const getGlobalNpmrc = () => {
 	if (isWindows && process.env.APPDATA) {
 		// Hardcoded contents of `c:\Program Files\nodejs\node_modules\npm\npmrc`
-		const npmrc = path.join(process.env.APPDATA, '/npm/etc/npmrc');
-		if (fs.existsSync(npmrc)) {
-			return npmrc;
-		}
+		return path.join(process.env.APPDATA, '/npm/etc/npmrc');
 	}
 
 	// Homebrew special case: `$(brew --prefix)/lib/node_modules/npm/npmrc`
 	if (process.execPath.endsWith('/Cellar/node')) {
 		const homebrewPrefix = path.dirname(path.dirname(process.execPath));
 		return path.join(homebrewPrefix, '/lib/node_modules/npm/npmrc');
+	}
+
+	if (process.execPath.endsWith('/bin/node')) {
+		const installDir = path.dirname(path.dirname(process.execPath));
+		return path.join(installDir, '/etc/npmrc');
 	}
 };
 
@@ -57,6 +55,10 @@ const getNpmPrefix = () => {
 	const homePrefix = readRc(path.join(os.homedir(), '.npmrc'));
 	if (homePrefix) {
 		return homePrefix;
+	}
+
+	if (process.env.PREFIX) {
+		return process.env.PREFIX;
 	}
 
 	const globalPrefix = readRc(getGlobalNpmrc());

--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ const getGlobalNpmrc = () => {
 	}
 
 	// Homebrew special case: `$(brew --prefix)/lib/node_modules/npm/npmrc`
-	const homebrewPrefix = '/usr/local';
-	if (process.execPath.startsWith(path.join(homebrewPrefix, '/Cellar/node'))) {
+	if (process.execPath.endsWith('/Cellar/node')) {
+		const homebrewPrefix = path.dirname(path.dirname(process.execPath));
 		return path.join(homebrewPrefix, '/lib/node_modules/npm/npmrc');
 	}
 };

--- a/index.js
+++ b/index.js
@@ -59,9 +59,8 @@ const getNpmPrefix = () => {
 		return homePrefix;
 	}
 
-	const globalNpmrc = getGlobalNpmrc();
-	if (globalNpmrc) {
-		const globalPrefix = readRc(globalNpmrc);
+	const globalPrefix = readRc(getGlobalNpmrc());
+	if (globalPrefix) {
 		return globalPrefix;
 	}
 
@@ -107,8 +106,8 @@ const getYarnPrefix = () => {
 
 exports.npm = {};
 exports.npm.prefix = npmPrefix;
-exports.npm.packages = path.join(npmPrefix, process.platform === 'win32' ? 'node_modules' : 'lib/node_modules');
-exports.npm.binaries = process.platform === 'win32' ? npmPrefix : path.join(npmPrefix, 'bin');
+exports.npm.packages = path.join(npmPrefix, isWindows ? 'node_modules' : 'lib/node_modules');
+exports.npm.binaries = isWindows ? npmPrefix : path.join(npmPrefix, 'bin');
 
 const yarnPrefix = path.resolve(getYarnPrefix());
 exports.yarn = {};


### PR DESCRIPTION
This PR brings in bunch of internal changes:
1. stop caculating `defaultNpmPrefix` eagerly
That's pretty much self explanatory because we might not need it in case `prefix` is being overridden by env or user config.
2. determining `defaultNpmPrefix` from `process.execPath` exclusively
In all other cases we should rely on found config file (user/global) and value written inside.
3. moving `%APPDATA%` (windows) and Homebrew related stuff to `getGlobalNpmrc`
This is not determining _global_ npm prefix but rather determining location of global `npmrc` config which should then be used to determine _global_ prefix.

To summarize:
1. if it is coming from `env` it is a `envPrefix`
2. if it is coming from user config it is a `homePrefix` determined from homedir's `npmrc`
3. if it is coming from global config (created during installation, like `%APPDATA%/npm/etc/npmrc` on Windows, or Homebrew's `$(brew --prefix)/lib/node_modules/npm/npmrc`) it is `globalPrefix` determined from `globalNpmrc`
4. if everything else fails default prefix is determined according to `process.execPath`